### PR TITLE
Fix climate state

### DIFF
--- a/components/balboa_spa/balboaspa.h
+++ b/components/balboa_spa/balboaspa.h
@@ -18,7 +18,7 @@ namespace balboa_spa {
 
 static const uint8_t ESPHOME_BALBOASPA_MIN_TEMPERATURE = 26;
 static const uint8_t ESPHOME_BALBOASPA_MAX_TEMPERATURE = 40;
-static const float   ESPHOME_BALBOASPA_POLLING_INTERVAL = 250; // frequency to poll uart device
+static const float   ESPHOME_BALBOASPA_POLLING_INTERVAL = 50; // frequency to poll uart device
 
 #define STRON String("ON").c_str()
 #define STROFF String("OFF").c_str()

--- a/components/balboa_spa/climate/spa_thermostat.cpp
+++ b/components/balboa_spa/climate/spa_thermostat.cpp
@@ -54,7 +54,7 @@ void BalboaSpaThermostat::update(SpaState* spaState) {
         this->action = climate::CLIMATE_ACTION_IDLE;
         update = true;
     }
-    else if(heat_state < 254 && this->action != climate::CLIMATE_ACTION_HEATING)
+    else if(heat_state == 1 && this->action != climate::CLIMATE_ACTION_HEATING)
     {
         this->action = climate::CLIMATE_ACTION_HEATING;
         update = true;
@@ -69,7 +69,7 @@ void BalboaSpaThermostat::update(SpaState* spaState) {
     }
     else if(rest_mode == 0 && this->mode != climate::CLIMATE_MODE_HEAT)
     {
-        this-> mode = climate::CLIMATE_MODE_HEAT;
+        this->mode = climate::CLIMATE_MODE_HEAT;
         update = true;
     }
 

--- a/components/balboa_spa/sensor/sensors.cpp
+++ b/components/balboa_spa/sensor/sensors.cpp
@@ -1,4 +1,3 @@
-#include <string>
 #include "esphome/core/log.h"
 #include "sensors.h"
 

--- a/components/balboa_spa/sensor/sensors.h
+++ b/components/balboa_spa/sensor/sensors.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "esphome/components/sensor/sensor.h"
 #include "../balboaspa.h"
 

--- a/components/balboa_spa/spa_state.cpp
+++ b/components/balboa_spa/spa_state.cpp
@@ -87,7 +87,7 @@ uint8_t SpaState::get_heat_state(){
         return 254;
     }
 
-    return target_temperatures.mode();
+    return heat_states.mode();
 }
 
 uint8_t SpaState::get_last_heat_state(){

--- a/components/balboa_spa/spa_state.h
+++ b/components/balboa_spa/spa_state.h
@@ -4,7 +4,7 @@
 #ifndef SPA_STATE_H
 #define SPA_STATE_H
 
-static const uint8_t ESPHOME_BALBOASPA_MEASUREMENT_POOL_SIZE = 10;
+static const uint8_t ESPHOME_BALBOASPA_MEASUREMENT_POOL_SIZE = 30;
 static const uint8_t ESPHOME_BALBOASPA_MEASUREMENT_COUNT_UNTIL_STABLE = 5;
 
 namespace esphome {

--- a/components/balboa_spa/spa_state.h
+++ b/components/balboa_spa/spa_state.h
@@ -4,7 +4,7 @@
 #ifndef SPA_STATE_H
 #define SPA_STATE_H
 
-static const uint8_t ESPHOME_BALBOASPA_MEASUREMENT_POOL_SIZE = 30;
+static const uint8_t ESPHOME_BALBOASPA_MEASUREMENT_POOL_SIZE = 20;
 static const uint8_t ESPHOME_BALBOASPA_MEASUREMENT_COUNT_UNTIL_STABLE = 5;
 
 namespace esphome {


### PR DESCRIPTION
This PR resolves https://github.com/brianfeucht/esphome-balboa-spa/issues/8

Primary fix here is to use `heat_states` instead of `target_temperatures` which was a copy pasta bug

I also made some tweaks to the value pool size and polling intervals to try to get a more stable state without increasing TTL for new values.  This seems to have prevented the flopping state I've and others have observed.