### PR TITLE
Temperature changes

### DIFF
--- a/components/balboa_spa/balboaspa.h
+++ b/components/balboa_spa/balboaspa.h
@@ -19,8 +19,13 @@ namespace balboa_spa {
 // https://github.com/espressif/arduino-esp32/blob/496b8411773243e1ad88a68652d6982ba2366d6b/cores/esp32/Arduino.h#L99
 #define bitRead(value, bit)            (((value) >> (bit)) & 0x01)
 
-static const uint8_t ESPHOME_BALBOASPA_MIN_TEMPERATURE = 7;
-static const uint8_t ESPHOME_BALBOASPA_MAX_TEMPERATURE = 40;
+/* TODO set right limit for Fahrenheit */
+static const uint8_t ESPHOME_BALBOASPA_MIN_TEMPERATURE_F = 7;
+static const uint8_t ESPHOME_BALBOASPA_MAX_TEMPERATURE_F = 40;
+
+static const uint8_t ESPHOME_BALBOASPA_MIN_TEMPERATURE_C = 7;
+static const uint8_t ESPHOME_BALBOASPA_MAX_TEMPERATURE_C = 40;
+
 static const float   ESPHOME_BALBOASPA_POLLING_INTERVAL = 50; // frequency to poll uart device
 
 #define STRON "ON"


### PR DESCRIPTION
Hi
Its me again. Thanks for pulling my stuff. 

Regarding the temperature changes.
`
Pool is set to 35°C, on the Original Spa Display. With your original temp code i get 21.11 in the log and in home assistant:

[13:03:01][D][Spa/config/status:179]: Getting config
[13:03:01][D][Spa/config/status:325]: Got config
[13:03:01][D][Spa/config/pumps1:340]: 1
[13:03:01][D][Spa/config/pumps2:341]: 1
[13:03:01][D][Spa/config/pumps3:342]: 1
[13:03:01][D][Spa/config/pumps4:343]: 0
[13:03:01][D][Spa/config/pumps5:344]: 0
[13:03:01][D][Spa/config/pumps6:345]: 0
[13:03:01][D][Spa/config/light1:346]: 1
[13:03:01][D][Spa/config/light2:347]: 0
[13:03:01][D][Spa/config/circ:348]: 1
[13:03:01][D][Spa/config/blower:349]: 1
[13:03:01][D][Spa/config/mister:350]: 0
[13:03:01][D][Spa/config/aux1:351]: 0
[13:03:01][D][Spa/config/aux2:352]: 0
[13:03:01][D][Spa/config/temp_scale:353]: 1
[13:03:01][D][Spa/debug/have_faultlog:190]: requesting fault log, #1
[13:03:19][D][BalboaSpa.component:128]: CRC 186 != Packet crc 126 end=0x5
[13:03:40][D][BalboaSpa.component:128]: CRC 210 != Packet crc 5 end=0x11
[13:03:43][D][BalboaSpa.component:128]: CRC 129 != Packet crc 126 end=0x7E
[13:03:43][D][BalboaSpa.component:128]: CRC 123 != Packet crc 25 end=0xBF
[13:03:51][I][safe_mode:042]: Boot seems successful; resetting boot loop counter
[13:03:51][D][esp32.preferences:142]: Writing 1 items: 0 cached, 1 written, 0 failed
[13:03:59][D][Spa/temperature/target:374]: 21.11
[13:03:59][D][Spa/temperature/state:400]: 21.11
[13:04:10][D][BalboaSpa.component:128]: CRC 218 != Packet crc 191 end=0x6

With changes: Its correct in logs and home assistant:

[13:18:10][D][Spa/config/status:181]: Getting config
[13:18:10][D][Spa/config/status:327]: Got config
[13:18:10][D][Spa/config/pumps1:342]: 1
[13:18:10][D][Spa/config/pumps2:343]: 1
[13:18:10][D][Spa/config/pumps3:344]: 1
[13:18:10][D][Spa/config/pumps4:345]: 0
[13:18:10][D][Spa/config/pumps5:346]: 0
[13:18:10][D][Spa/config/pumps6:347]: 0
[13:18:10][D][Spa/config/light1:348]: 1
[13:18:10][D][Spa/config/light2:349]: 0
[13:18:10][D][Spa/config/circ:350]: 1
[13:18:10][D][Spa/config/blower:351]: 1
[13:18:10][D][Spa/config/mister:352]: 0
[13:18:10][D][Spa/config/aux1:353]: 0
[13:18:10][D][Spa/config/aux2:354]: 0
[13:18:10][D][Spa/config/temp_scale:355]: 1
[13:18:11][D][Spa/debug/have_faultlog:192]: requesting fault log, #1
[13:18:11][D][Spa/fault/Entries:576]: 11
[13:18:11][D][Spa/fault/Entry:577]: 10
[13:18:11][D][Spa/fault/Code:578]: 19
[13:18:11][D][Spa/fault/Message:579]: Priming Mode
[13:18:11][D][Spa/fault/DaysAgo:580]: 68
[13:18:11][D][Spa/fault/Hours:581]: 12
[13:18:11][D][Spa/fault/Minutes:582]: 0
[13:18:12][D][Spa/debug/have_filtersettings:201]: requesting filter settings, #1
[13:18:12][D][Spa/debug/have_faultlog:235]: decoding filter settings
[13:18:12][D][Spa/filter1/state:497]: {"start":"08:00","duration":"05:00"}
[13:18:12][D][Spa/filter2_enabled/state:500]: ON
[13:18:12][D][Spa/filter2/state:502]: {"start":"14:00","duration":"05:00"}
[13:18:17][D][BalboaSpa.component:130]: CRC 44 != Packet crc 92 end=0xFE
[13:18:17][D][BalboaSpa.component:130]: CRC 26 != Packet crc 247 end=0x7E
[13:18:27][D][BalboaSpa.component:130]: CRC 91 != Packet crc 255 end=0x7E
[13:18:27][D][BalboaSpa.component:130]: CRC 125 != Packet crc 0 end=0x3
[13:18:28][D][BalboaSpa.component:130]: CRC 230 != Packet crc 255 end=0x7E
[13:18:28][D][BalboaSpa.component:130]: CRC 26 != Packet crc 247 end=0x7E
[13:18:29][D][BalboaSpa.component:130]: CRC 12 != Packet crc 6 end=0xE1
[13:18:32][D][BalboaSpa.component:130]: CRC 99 != Packet crc 126 end=0x5
[13:18:45][D][BalboaSpa.component:130]: CRC 12 != Packet crc 225 end=0x7E
[13:18:46][D][climate:011]: 'Thermostat' - Setting
[13:18:47][D][climate:040]:   Target Temperature: 35.50
[13:18:47][D][Spa/temperature/target:378]: 35.50
[13:18:47][D][Spa/temperature/state:404]: 35.00
[13:18:47][D][Spa/circ/state:456]: 1
[13:18:47][D][binary_sensor:036]: 'Circulation': Sending state ON
[13:18:47][D][climate:396]: 'Thermostat' - Sending state:
[13:18:47][D][climate:399]:   Mode: HEAT
[13:18:47][D][climate:401]:   Action: IDLE
[13:18:47][D][climate:410]:   Preset: HOME
[13:18:47][D][climate:419]:   Current Temperature: 35.00°C
[13:18:47][D][climate:425]:   Target Temperature: 35.50°C
[13:18:47][D][BalboaSpa.component:130]: CRC 12 != Packet crc 6 end=0xE1
[13:18:49][D][BalboaSpa.component:130]: CRC 12 != Packet crc 6 end=0xE1
[13:18:57][I][safe_mode:042]: Boot seems successful; resetting boot loop counter
[13:18:57][D][esp32.preferences:142]: Writing 1 items: 0 cached, 1 written, 0 failed
[13:19:10][D][Spa/temperature/target:378]: 35.50
[13:19:10][D][Spa/temperature/state:404]: 35.00
`

This is also like its described here:
https://github.com/ccutrer/balboa_worldwide_app/wiki#flags-byte-9
      Bits	Flag	Values
      0	Temperature Scale	0=1°F, 1=0.5°C

They simply multiply by 2 or divide by 2 to get rid of the decimal point.
Since °F only has whole numbers, no conversion is neccessary.

And yes i do get many crc errors.
[crc_errs.txt](https://github.com/user-attachments/files/20882888/crc_errs.txt)
