### PR TITLE
jet3_read

### DIFF
--- a/components/balboa_spa/balboaspa.cpp
+++ b/components/balboa_spa/balboaspa.cpp
@@ -445,6 +445,13 @@ void BalboaSpa::read_serial() {
       spaState.jet2 = d;
     }
 
+    d = bitRead(Q_in[16], 5);
+    if (d != spaState.jet3) 
+    {
+      ESP_LOGD("Spa/jet_3/state", "%.0f", d);
+      spaState.jet3 = d;
+    }
+
     // 18:Flags Byte 13
     d = bitRead(Q_in[18], 1);
     if (d != spaState.circulation)


### PR DESCRIPTION
Just noticed you imported my changes for jet3 except in read_serial() so the value never makes it back to the esp