### PR TITLE
Retry unsucessfull toggle of switches

### DIFF
--- a/components/balboa_spa/spa_types.h
+++ b/components/balboa_spa/spa_types.h
@@ -28,6 +28,20 @@ namespace balboa_spa {
         uint8_t filter2_duration_minute :6;
 
     };
+
+    enum ToggleStateMaybe {
+        OFF = 0,
+        ON,
+        HIGH,
+        DONT_KNOW
+    };
+
+    static const char* TOGGLE_STATE_MAYBE_STRINGS[] = {
+        "OFF",
+        "ON",
+        "HIGH",
+        "DONT_KNOW"
+    };
 }  // namespace balboa_spa
 }  // namespace esphome
 

--- a/components/balboa_spa/switch/__init__.py
+++ b/components/balboa_spa/switch/__init__.py
@@ -37,7 +37,7 @@ def jet_switch_schema(cls):
         icon=ICON_FAN,
         default_restore_mode="DISABLED",
     ).extend({
-        cv.Optional(CONF_DISCARD_UPDATES, default=10): cv.positive_int,
+        cv.Optional(CONF_DISCARD_UPDATES, default=20): cv.positive_int,
     })
 
 CONFIG_SCHEMA = cv.Schema(
@@ -57,7 +57,7 @@ CONFIG_SCHEMA = cv.Schema(
             icon=ICON_GRAIN,
             default_restore_mode="DISABLED",
         ).extend({
-            cv.Optional(CONF_DISCARD_UPDATES, default=10): cv.positive_int,
+            cv.Optional(CONF_DISCARD_UPDATES, default=20): cv.positive_int,
         }),
     })
 

--- a/components/balboa_spa/switch/__init__.py
+++ b/components/balboa_spa/switch/__init__.py
@@ -29,30 +29,24 @@ CONF_JET3 = "jet3"
 CONF_JET4 = "jet4"
 CONF_LIGHTS = "light"
 CONF_BLOWER = "blower"
+CONF_DISCARD_UPDATES = "discard_updates"
+
+def jet_switch_schema(cls):
+    return switch.switch_schema(
+        cls,
+        icon=ICON_FAN,
+        default_restore_mode="DISABLED",
+    ).extend({
+        cv.Optional(CONF_DISCARD_UPDATES, default=10): cv.positive_int,
+    })
 
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_SPA_ID): cv.use_id(BalboaSpa),
-        cv.Optional(CONF_JET1): switch.switch_schema(
-            Jet1Switch,
-            icon=ICON_FAN,
-            default_restore_mode="DISABLED",
-        ),
-        cv.Optional(CONF_JET2): switch.switch_schema(
-            Jet2Switch,
-            icon=ICON_FAN,
-            default_restore_mode="DISABLED",
-        ),
-        cv.Optional(CONF_JET3): switch.switch_schema(
-            Jet3Switch,
-            icon=ICON_FAN,
-            default_restore_mode="DISABLED",
-        ),
-        cv.Optional(CONF_JET4): switch.switch_schema(
-            Jet4Switch,
-            icon=ICON_FAN,
-            default_restore_mode="DISABLED",
-        ),
+        cv.Optional(CONF_JET1): jet_switch_schema(Jet1Switch),
+        cv.Optional(CONF_JET2): jet_switch_schema(Jet2Switch),
+        cv.Optional(CONF_JET3): jet_switch_schema(Jet3Switch),
+        cv.Optional(CONF_JET4): jet_switch_schema(Jet4Switch),
         cv.Optional(CONF_LIGHTS): switch.switch_schema(
             LightsSwitch,
             icon=ICON_LIGHTBULB,
@@ -62,13 +56,24 @@ CONFIG_SCHEMA = cv.Schema(
             BlowerSwitch,
             icon=ICON_GRAIN,
             default_restore_mode="DISABLED",
-        ),
+        ).extend({
+            cv.Optional(CONF_DISCARD_UPDATES, default=10): cv.positive_int,
+        }),
     })
 
 async def to_code(config):
     parent = await cg.get_variable(config[CONF_SPA_ID])
 
-    for switch_type in [CONF_JET1, CONF_JET2, CONF_JET3, CONF_JET4, CONF_LIGHTS, CONF_BLOWER]:
+    for switch_type, cls in [
+        (CONF_JET1, Jet1Switch),
+        (CONF_JET2, Jet2Switch),
+        (CONF_JET3, Jet3Switch),
+        (CONF_JET4, Jet4Switch),
+        (CONF_BLOWER, BlowerSwitch),
+        (CONF_LIGHTS, LightsSwitch),
+    ]:
         if conf := config.get(switch_type):
             sw_var = await switch.new_switch(conf)
             cg.add(sw_var.set_parent(parent))
+            if CONF_DISCARD_UPDATES in conf:
+                cg.add(sw_var.set_discard_updates(conf[CONF_DISCARD_UPDATES]))

--- a/components/balboa_spa/switch/blower_switch.cpp
+++ b/components/balboa_spa/switch/blower_switch.cpp
@@ -2,23 +2,45 @@
 
 namespace esphome {
 namespace balboa_spa {
-void BlowerSwitch::update(SpaState* spaState) {
-    if(this->state != spaState->blower)
-    {
-        this->publish_state(spaState->blower);
+
+void BlowerSwitch::update(const SpaState* spaState) {
+    if (this->discard_updates > 0) {
+        this->discard_updates--;
+        return;
     }
+    if(this->state != spaState->blower && this->setState == ToggleStateMaybe::DONT_KNOW) {
+        this->publish_state(spaState->blower);
+        ESP_LOGD("blower_swtich", "Blower switch state updated to %s", spaState->blower ? STRON : STROFF);
+    } else if (this->setState == ToggleStateMaybe::ON && !spaState->blower) {
+        this->toggle_blower();
+        ESP_LOGD("blower_swtich", "Blower state changed %s setState is ON, toggling blower", state ? STRON : STROFF);
+    } else if (this->setState == ToggleStateMaybe::OFF && spaState->blower) {
+        this->toggle_blower();
+        ESP_LOGD("blower_swtich", "Blower state changed %s setState is OFF, toggling blower", state ? STRON : STROFF);
+    } else if (this->setState != ToggleStateMaybe::DONT_KNOW) {
+        this->setState = ToggleStateMaybe::DONT_KNOW;
+        ESP_LOGD("blower_swtich", "write_state sucessful, setState is now DONT_KNOW");
+    }
+    
+}
+
+void BlowerSwitch::toggle_blower() {
+    spa->toggle_blower();
+    this->discard_updates = this->discard_updates_config_;
+    ESP_LOGD("blower_swtich", "Blower wants %s, discard_updates set to %d", TOGGLE_STATE_MAYBE_STRINGS[this->setState], this->discard_updates);
 }
 
 void BlowerSwitch::set_parent(BalboaSpa *parent) {
     spa = parent;
-    parent->register_listener([this](SpaState* spaState){ this->update(spaState); });
+    parent->register_listener([this](const SpaState* spaState){ this->update(spaState); });
 }
 
 void BlowerSwitch::write_state(bool state) {
     SpaState* spaState = spa->get_current_state();
 
     if(spaState->blower != state){
-        spa->toggle_blower();
+        this->setState = state ? ToggleStateMaybe::ON : ToggleStateMaybe::OFF;
+        this->toggle_blower();
     }
 }
 

--- a/components/balboa_spa/switch/blower_switch.h
+++ b/components/balboa_spa/switch/blower_switch.h
@@ -8,16 +8,21 @@ namespace esphome {
 namespace balboa_spa {
 
 class BlowerSwitch : public switch_::Switch {
- public:
-  BlowerSwitch() {};
-  void update(SpaState* spaState);
-  void set_parent(BalboaSpa *parent);
+  public:
+    BlowerSwitch() {};
+    void update(const SpaState* spaState);
+    void set_parent(BalboaSpa *parent);
+    void set_discard_updates(uint8_t value) { this->discard_updates_config_ = value; }
 
   protected:
     void write_state(bool state) override;
     
   private:
-    BalboaSpa *spa;
+    void toggle_blower();
+    BalboaSpa *spa = nullptr;
+    ToggleStateMaybe setState = ToggleStateMaybe::DONT_KNOW;
+    uint8_t discard_updates = 0;
+    uint8_t discard_updates_config_ = 10;
 };
 
 }  // namespace balboa_spa

--- a/components/balboa_spa/switch/jet1_switch.cpp
+++ b/components/balboa_spa/switch/jet1_switch.cpp
@@ -3,23 +3,43 @@
 namespace esphome {
 namespace balboa_spa {
 
-void Jet1Switch::update(SpaState* spaState) {
-    if(this->state != spaState->jet1)
-    {
-        this->publish_state(spaState->jet1);
+void Jet1Switch::update(const SpaState* spaState) {
+    if (this->discard_updates > 0) {
+        this->discard_updates--;
+        return;
     }
+    if(this->state != spaState->jet1 && this->setState == ToggleStateMaybe::DONT_KNOW) {
+        this->publish_state(spaState->jet1);
+        ESP_LOGD("jet1_switch", "Jet1 switch state updated to %s", spaState->jet1 ? STRON : STROFF);
+    } else if (this->setState == ToggleStateMaybe::ON && !spaState->jet1) {
+        this->toggle_jet1();
+        ESP_LOGD("jet1_switch", "Jet1 state changed %s setState is ON, toggling jet1", state ? STRON : STROFF);
+    } else if (this->setState == ToggleStateMaybe::OFF && spaState->jet1) {
+        this->toggle_jet1();
+        ESP_LOGD("jet1_switch", "Jet1 state changed %s setState is OFF, toggling jet1", state ? STRON : STROFF);
+    } else if (this->setState != ToggleStateMaybe::DONT_KNOW) {
+        this->setState = ToggleStateMaybe::DONT_KNOW;
+        ESP_LOGD("jet1_switch", "write_state successful, setState is now DONT_KNOW");
+    }
+}
+
+void Jet1Switch::toggle_jet1() {
+    spa->toggle_jet1();
+    this->discard_updates = this->discard_updates_config_;
+    ESP_LOGD("jet1_switch", "Jet1 wants %s, discard_updates set to %d", TOGGLE_STATE_MAYBE_STRINGS[this->setState], this->discard_updates);
 }
 
 void Jet1Switch::set_parent(BalboaSpa *parent) {
     spa = parent;
-    parent->register_listener([this](SpaState* spaState){ this->update(spaState); });
+    parent->register_listener([this](const SpaState* spaState){ this->update(spaState); });
 }
 
 void Jet1Switch::write_state(bool state) {
     SpaState* spaState = spa->get_current_state();
 
     if(spaState->jet1 != state){
-        spa->toggle_jet1();
+        this->setState = state ? ToggleStateMaybe::ON : ToggleStateMaybe::OFF;
+        this->toggle_jet1();
     }
 }
 

--- a/components/balboa_spa/switch/jet1_switch.h
+++ b/components/balboa_spa/switch/jet1_switch.h
@@ -8,16 +8,21 @@ namespace esphome {
 namespace balboa_spa {
 
 class Jet1Switch : public switch_::Switch {
- public:
-  Jet1Switch() {};
-  void update(SpaState* spaState);
-  void set_parent(BalboaSpa *parent);
+  public:
+    Jet1Switch() {};
+    void update(const SpaState* spaState);
+    void set_parent(BalboaSpa *parent);
+    void set_discard_updates(uint8_t value) { this->discard_updates_config_ = value; }
 
   protected:
     void write_state(bool state) override;
 
   private:
-    BalboaSpa *spa;    
+    void toggle_jet1();
+    BalboaSpa *spa = nullptr;
+    ToggleStateMaybe setState = ToggleStateMaybe::DONT_KNOW;
+    uint8_t discard_updates = 0;
+    uint8_t discard_updates_config_ = 10;
 };
 
 }  // namespace balboa_spa

--- a/components/balboa_spa/switch/jet2_switch.cpp
+++ b/components/balboa_spa/switch/jet2_switch.cpp
@@ -2,23 +2,44 @@
 
 namespace esphome {
 namespace balboa_spa {
-void Jet2Switch::update(SpaState* spaState) {
-    if(this->state != spaState->jet2)
-    {
-        this->publish_state(spaState->jet2);
+
+void Jet2Switch::update(const SpaState* spaState) {
+    if (this->discard_updates > 0) {
+        this->discard_updates--;
+        return;
     }
+    if(this->state != spaState->jet2 && this->setState == ToggleStateMaybe::DONT_KNOW) {
+        this->publish_state(spaState->jet2);
+        ESP_LOGD("jet2_switch", "Jet2 switch state updated to %s", spaState->jet2 ? STRON : STROFF);
+    } else if (this->setState == ToggleStateMaybe::ON && !spaState->jet2) {
+        this->toggle_jet2();
+        ESP_LOGD("jet2_switch", "Jet2 state changed %s setState is ON, toggling jet2", state ? STRON : STROFF);
+    } else if (this->setState == ToggleStateMaybe::OFF && spaState->jet2) {
+        this->toggle_jet2();
+        ESP_LOGD("jet2_switch", "Jet2 state changed %s setState is OFF, toggling jet2", state ? STRON : STROFF);
+    } else if (this->setState != ToggleStateMaybe::DONT_KNOW) {
+        this->setState = ToggleStateMaybe::DONT_KNOW;
+        ESP_LOGD("jet2_switch", "write_state successful, setState is now DONT_KNOW");
+    }
+}
+
+void Jet2Switch::toggle_jet2() {
+    spa->toggle_jet2();
+    this->discard_updates = this->discard_updates_config_;
+    ESP_LOGD("jet2_switch", "Jet2 wants %s, discard_updates set to %d", TOGGLE_STATE_MAYBE_STRINGS[this->setState], this->discard_updates);
 }
 
 void Jet2Switch::set_parent(BalboaSpa *parent) {
     spa = parent;
-    parent->register_listener([this](SpaState* spaState){ this->update(spaState); });
+    parent->register_listener([this](const SpaState* spaState){ this->update(spaState); });
 }
 
-void Jet2Switch::write_state(bool state)  { 
+void Jet2Switch::write_state(bool state) {
     SpaState* spaState = spa->get_current_state();
 
     if(spaState->jet2 != state){
-        spa->toggle_jet2();
+        this->setState = state ? ToggleStateMaybe::ON : ToggleStateMaybe::OFF;
+        this->toggle_jet2();
     }
 }
 

--- a/components/balboa_spa/switch/jet2_switch.h
+++ b/components/balboa_spa/switch/jet2_switch.h
@@ -8,16 +8,21 @@ namespace esphome {
 namespace balboa_spa {
 
 class Jet2Switch : public switch_::Switch {
- public:
-  Jet2Switch() {};
-  void update(SpaState* spaState);
-  void set_parent(BalboaSpa *parent);
+  public:
+    Jet2Switch() {};
+    void update(const SpaState* spaState);
+    void set_parent(BalboaSpa *parent);
+    void set_discard_updates(uint8_t value) { this->discard_updates_config_ = value; }
 
   protected:
     void write_state(bool state) override;
 
   private:
-    BalboaSpa *spa;
+    void toggle_jet2();
+    BalboaSpa *spa = nullptr;
+    ToggleStateMaybe setState = ToggleStateMaybe::DONT_KNOW;
+    uint8_t discard_updates = 0;
+    uint8_t discard_updates_config_ = 10;
 };
 
 }  // namespace balboa_spa

--- a/components/balboa_spa/switch/jet3_switch.cpp
+++ b/components/balboa_spa/switch/jet3_switch.cpp
@@ -2,23 +2,44 @@
 
 namespace esphome {
 namespace balboa_spa {
-void Jet3Switch::update(SpaState* spaState) {
-    if(this->state != spaState->jet3)
-    {
-        this->publish_state(spaState->jet3);
+
+void Jet3Switch::update(const SpaState* spaState) {
+    if (this->discard_updates > 0) {
+        this->discard_updates--;
+        return;
     }
+    if(this->state != spaState->jet3 && this->setState == ToggleStateMaybe::DONT_KNOW) {
+        this->publish_state(spaState->jet3);
+        ESP_LOGD("jet3_switch", "Jet3 switch state updated to %s", spaState->jet3 ? STRON : STROFF);
+    } else if (this->setState == ToggleStateMaybe::ON && !spaState->jet3) {
+        this->toggle_jet3();
+        ESP_LOGD("jet3_switch", "Jet3 state changed %s setState is ON, toggling jet3", state ? STRON : STROFF);
+    } else if (this->setState == ToggleStateMaybe::OFF && spaState->jet3) {
+        this->toggle_jet3();
+        ESP_LOGD("jet3_switch", "Jet3 state changed %s setState is OFF, toggling jet3", state ? STRON : STROFF);
+    } else if (this->setState != ToggleStateMaybe::DONT_KNOW) {
+        this->setState = ToggleStateMaybe::DONT_KNOW;
+        ESP_LOGD("jet3_switch", "write_state successful, setState is now DONT_KNOW");
+    }
+}
+
+void Jet3Switch::toggle_jet3() {
+    spa->toggle_jet3();
+    this->discard_updates = this->discard_updates_config_;
+    ESP_LOGD("jet3_switch", "Jet3 wants %s, discard_updates set to %d", TOGGLE_STATE_MAYBE_STRINGS[this->setState], this->discard_updates);
 }
 
 void Jet3Switch::set_parent(BalboaSpa *parent) {
     spa = parent;
-    parent->register_listener([this](SpaState* spaState){ this->update(spaState); });
+    parent->register_listener([this](const SpaState* spaState){ this->update(spaState); });
 }
 
-void Jet3Switch::write_state(bool state)  { 
+void Jet3Switch::write_state(bool state) {
     SpaState* spaState = spa->get_current_state();
 
     if(spaState->jet3 != state){
-        spa->toggle_jet3();
+        this->setState = state ? ToggleStateMaybe::ON : ToggleStateMaybe::OFF;
+        this->toggle_jet3();
     }
 }
 

--- a/components/balboa_spa/switch/jet3_switch.h
+++ b/components/balboa_spa/switch/jet3_switch.h
@@ -8,16 +8,21 @@ namespace esphome {
 namespace balboa_spa {
 
 class Jet3Switch : public switch_::Switch {
- public:
-  Jet3Switch() {};
-  void update(SpaState* spaState);
-  void set_parent(BalboaSpa *parent);
+  public:
+    Jet3Switch() {};
+    void update(const SpaState* spaState);
+    void set_parent(BalboaSpa *parent);
+    void set_discard_updates(uint8_t value) { this->discard_updates_config_ = value; }
 
   protected:
     void write_state(bool state) override;
 
   private:
-    BalboaSpa *spa;
+    void toggle_jet3();
+    BalboaSpa *spa = nullptr;
+    ToggleStateMaybe setState = ToggleStateMaybe::DONT_KNOW;
+    uint8_t discard_updates = 0;
+    uint8_t discard_updates_config_ = 10;
 };
 
 }  // namespace balboa_spa

--- a/components/balboa_spa/switch/jet4_switch.cpp
+++ b/components/balboa_spa/switch/jet4_switch.cpp
@@ -2,23 +2,44 @@
 
 namespace esphome {
 namespace balboa_spa {
-void Jet4Switch::update(SpaState* spaState) {
-    if(this->state != spaState->jet4)
-    {
-        this->publish_state(spaState->jet4);
+
+void Jet4Switch::update(const SpaState* spaState) {
+    if (this->discard_updates > 0) {
+        this->discard_updates--;
+        return;
     }
+    if(this->state != spaState->jet4 && this->setState == ToggleStateMaybe::DONT_KNOW) {
+        this->publish_state(spaState->jet4);
+        ESP_LOGD("jet4_switch", "Jet4 switch state updated to %s", spaState->jet4 ? STRON : STROFF);
+    } else if (this->setState == ToggleStateMaybe::ON && !spaState->jet4) {
+        this->toggle_jet4();
+        ESP_LOGD("jet4_switch", "Jet4 state changed %s setState is ON, toggling jet4", state ? STRON : STROFF);
+    } else if (this->setState == ToggleStateMaybe::OFF && spaState->jet4) {
+        this->toggle_jet4();
+        ESP_LOGD("jet4_switch", "Jet4 state changed %s setState is OFF, toggling jet4", state ? STRON : STROFF);
+    } else if (this->setState != ToggleStateMaybe::DONT_KNOW) {
+        this->setState = ToggleStateMaybe::DONT_KNOW;
+        ESP_LOGD("jet4_switch", "write_state successful, setState is now DONT_KNOW");
+    }
+}
+
+void Jet4Switch::toggle_jet4() {
+    spa->toggle_jet4();
+    this->discard_updates = this->discard_updates_config_;
+    ESP_LOGD("jet4_switch", "Jet4 wants %s, discard_updates set to %d", TOGGLE_STATE_MAYBE_STRINGS[this->setState], this->discard_updates);
 }
 
 void Jet4Switch::set_parent(BalboaSpa *parent) {
     spa = parent;
-    parent->register_listener([this](SpaState* spaState){ this->update(spaState); });
+    parent->register_listener([this](const SpaState* spaState){ this->update(spaState); });
 }
 
-void Jet4Switch::write_state(bool state)  {
+void Jet4Switch::write_state(bool state) {
     SpaState* spaState = spa->get_current_state();
 
     if(spaState->jet4 != state){
-        spa->toggle_jet4();
+        this->setState = state ? ToggleStateMaybe::ON : ToggleStateMaybe::OFF;
+        this->toggle_jet4();
     }
 }
 

--- a/components/balboa_spa/switch/jet4_switch.h
+++ b/components/balboa_spa/switch/jet4_switch.h
@@ -8,16 +8,21 @@ namespace esphome {
 namespace balboa_spa {
 
 class Jet4Switch : public switch_::Switch {
- public:
-  Jet4Switch() {};
-  void update(SpaState* spaState);
-  void set_parent(BalboaSpa *parent);
+  public:
+    Jet4Switch() {};
+    void update(const SpaState* spaState);
+    void set_parent(BalboaSpa *parent);
+    void set_discard_updates(uint8_t value) { this->discard_updates_config_ = value; }
 
   protected:
     void write_state(bool state) override;
 
   private:
-    BalboaSpa *spa;
+    void toggle_jet4();
+    BalboaSpa *spa = nullptr;
+    ToggleStateMaybe setState = ToggleStateMaybe::DONT_KNOW;
+    uint8_t discard_updates = 0;
+    uint8_t discard_updates_config_ = 10;
 };
 
 }  // namespace balboa_spa


### PR DESCRIPTION
Hi

Sometimes the Mainboard ignores (most likely CRC errors when sending) when i toggle switches.
The problem is most notable when I try to toggle more then 1 switch at the same time.
With this changes i successfully toggled all switches at the the same time 10 times in a row.

I added a undocumented config entry:
```
switch:
  - platform: balboa_spa
    balboa_spa_id: spa
    jet1:
      name: "Gegenstrom #1"
      discard_updates: 20
    jet2:
      name: "Gegenstrom #2"
      discard_updates: 20
    jet3:
      name: "Gegenstrom #3"
      discard_updates: 20
    light:
      name: Licht
    blower:
      name: "Gebläse"
      discard_updates: 20
```

discard_updates default value is 20, which worked best for me