### PR TITLE
Implement time sync button

### DIFF
--- a/components/balboa_spa/balboaspa.cpp
+++ b/components/balboa_spa/balboaspa.cpp
@@ -115,6 +115,12 @@ namespace esphome
             send_command = 0x51;
         }
 
+        void BalboaSpa::request_config_update()
+        {
+            ESP_LOGD(TAG, "Requesting spa config update");
+            config_request_status = 0; // Reset to request config again
+        }
+
         void BalboaSpa::set_hour(int hour)
         {
             if (hour >= 0 && hour <= 23)

--- a/components/balboa_spa/balboaspa.h
+++ b/components/balboa_spa/balboaspa.h
@@ -72,6 +72,7 @@ namespace esphome
 
       bool get_restmode();
       void toggle_heat();
+      void request_config_update();
 
     private:
       CircularBuffer<uint8_t, 100> input_queue;

--- a/components/balboa_spa/button/__init__.py
+++ b/components/balboa_spa/button/__init__.py
@@ -1,0 +1,21 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import button
+from .. import balboa_spa_ns, BalboaSpa, CONF_SPA_ID
+
+DEPENDENCIES = ["balboa_spa"]
+
+SyncTimeButton = balboa_spa_ns.class_("SyncTimeButton", button.Button)
+
+CONF_SYNC_TIME = "sync_time"
+
+CONFIG_SCHEMA = cv.Schema({
+    cv.GenerateID(CONF_SPA_ID): cv.use_id(BalboaSpa),
+    cv.Optional(CONF_SYNC_TIME): button.button_schema(SyncTimeButton),
+})
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_SPA_ID])
+    if conf := config.get(CONF_SYNC_TIME):
+        var = await button.new_button(conf)
+        cg.add(var.set_parent(parent))

--- a/components/balboa_spa/button/sync_time_button.cpp
+++ b/components/balboa_spa/button/sync_time_button.cpp
@@ -31,6 +31,10 @@ namespace esphome
             parent_->set_hour(time_info->tm_hour);
             parent_->set_minute(time_info->tm_min);
             ESP_LOGI(TAG, "Spa time sync triggered: %02d:%02d", time_info->tm_hour, time_info->tm_min);
+            
+            // Request spa settings update to refresh the display
+            parent_->request_config_update();
+            ESP_LOGD(TAG, "Requested spa config update after time sync");
         }
 
     } // namespace balboa_spa

--- a/components/balboa_spa/button/sync_time_button.cpp
+++ b/components/balboa_spa/button/sync_time_button.cpp
@@ -1,0 +1,37 @@
+#include "sync_time_button.h"
+#include "esphome/core/log.h"
+#include "esphome/core/helpers.h"
+
+namespace esphome
+{
+    namespace balboa_spa
+    {
+        static const char *TAG = "balboa_spa.button";
+
+        void SyncTimeButton::set_parent(BalboaSpa *parent)
+        {
+            parent_ = parent;
+        }
+
+        void SyncTimeButton::press_action()
+        {
+            ESP_LOGD(TAG, "Sync time button pressed");
+
+            // Use the current system time (epoch time converted to local time)
+            time_t now_timestamp = time(nullptr);
+            struct tm *time_info = localtime(&now_timestamp);
+
+            if (time_info == nullptr || now_timestamp < 1000000000) // Basic validity check
+            {
+                ESP_LOGW(TAG, "System time not valid yet");
+                return;
+            }
+
+            // Set the spa time
+            parent_->set_hour(time_info->tm_hour);
+            parent_->set_minute(time_info->tm_min);
+            ESP_LOGI(TAG, "Spa time sync triggered: %02d:%02d", time_info->tm_hour, time_info->tm_min);
+        }
+
+    } // namespace balboa_spa
+} // namespace esphome

--- a/components/balboa_spa/button/sync_time_button.h
+++ b/components/balboa_spa/button/sync_time_button.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "esphome/components/button/button.h"
+#include "../balboaspa.h"
+
+namespace esphome
+{
+    namespace balboa_spa
+    {
+
+        class SyncTimeButton : public button::Button
+        {
+        public:
+            void set_parent(BalboaSpa *parent);
+
+        protected:
+            void press_action() override;
+
+        private:
+            BalboaSpa *parent_;
+        };
+
+    } // namespace balboa_spa
+} // namespace esphome

--- a/test_balboa_spa_component.yaml
+++ b/test_balboa_spa_component.yaml
@@ -77,3 +77,9 @@ text_sensor:
       name: "Filter 1 Config"
     filter2_config:
       name: "Filter 2 Config"
+
+button:
+  - platform: balboa_spa
+    balboa_spa_id: test_spa
+    sync_time:
+      name: "Sync Spa Time"


### PR DESCRIPTION
Resolves https://github.com/brianfeucht/esphome-balboa-spa/issues/61

This requires the following components:

```
time:
  - platform: homeassistant
  
# Enable Home Assistant API
api:


button:
  - platform: balboa_spa
    balboa_spa_id: hot_tub
    sync_time:
      name: "Sync Spa Time"
```