### PR TITLE
Add property to allow for client_id to be overriden

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ balboa_spa:
   id: spa
   # Set this to C or F based on the units your spa is configured for
   spa_temp_scale: F
+  # Optional: Override the automatically assigned client ID
+  # client_id: 10
 
 switch:
   - platform: balboa_spa

--- a/components/balboa_spa/__init__.py
+++ b/components/balboa_spa/__init__.py
@@ -8,6 +8,7 @@ DEPENDENCIES = ['uart']
 CONF_SPA_ID = "balboa_spa_id"
 CONF_SPA_TEMP_SCALE = "spa_temp_scale"
 CONF_ESPHOME_TEMP_SCALE = "esphome_temp_scale"
+CONF_CLIENT_ID = "client_id"
 
 balboa_spa_ns = cg.esphome_ns.namespace('balboa_spa')
 BalboaSpa = balboa_spa_ns.class_('BalboaSpa', cg.Component, uart.UARTDevice)
@@ -23,6 +24,7 @@ CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(BalboaSpa),
     cv.Optional(CONF_SPA_TEMP_SCALE, default=254): cv.enum(TEMP_SCALES, upper=True),
     cv.Optional(CONF_ESPHOME_TEMP_SCALE, default="C"): cv.enum(TEMP_SCALES, upper=True),
+    cv.Optional(CONF_CLIENT_ID): cv.int_range(min=1, max=47),
 }).extend(cv.COMPONENT_SCHEMA).extend(uart.UART_DEVICE_SCHEMA)
 
 def to_code(config):
@@ -34,5 +36,8 @@ def to_code(config):
 
     if esphome_temp_scale_conf := config.get(CONF_ESPHOME_TEMP_SCALE):
         cg.add(var.set_esphome_temp_scale(esphome_temp_scale_conf))
+
+    if client_id_conf := config.get(CONF_CLIENT_ID):
+        cg.add(var.set_client_id(client_id_conf))
 
     yield uart.register_uart_device(var, config)

--- a/components/balboa_spa/balboaspa.cpp
+++ b/components/balboa_spa/balboaspa.cpp
@@ -319,10 +319,18 @@ namespace esphome
                     // FE BF 02:got new client ID
                     if (input_queue[2] == 0xFE && input_queue[4] == 0x02)
                     {
-                        client_id = input_queue[5];
-                        if (client_id > 0x2F)
-                            client_id = 0x2F;
-                        ESP_LOGD(TAG, "Spa/node/id: Got ID: %d, acknowledging", client_id);
+                        if (use_client_id_override)
+                        {
+                            client_id = client_id_override;
+                            ESP_LOGD(TAG, "Spa/node/id: Using override ID: %d, acknowledging", client_id);
+                        }
+                        else
+                        {
+                            client_id = input_queue[5];
+                            if (client_id > 0x2F)
+                                client_id = 0x2F;
+                            ESP_LOGD(TAG, "Spa/node/id: Got ID: %d, acknowledging", client_id);
+                        }
                         ID_ack();
                         ESP_LOGD(TAG, "Spa/node/id: %d", client_id);
                     }
@@ -898,6 +906,20 @@ namespace esphome
         void BalboaSpa::set_esphome_temp_scale(TEMP_SCALE scale)
         {
             esphome_temp_scale = scale;
+        }
+
+        void BalboaSpa::set_client_id(uint8_t id)
+        {
+            if (id >= 1 && id <= 0x2F)
+            {
+                client_id_override = id;
+                use_client_id_override = true;
+                ESP_LOGD(TAG, "Client ID override set to %d", id);
+            }
+            else
+            {
+                ESP_LOGW(TAG, "Invalid client ID override %d, must be between 1 and 47", id);
+            }
         }
 
         float BalboaSpa::convert_c_to_f(float c)

--- a/components/balboa_spa/balboaspa.h
+++ b/components/balboa_spa/balboaspa.h
@@ -72,6 +72,7 @@ namespace esphome
 
       void set_spa_temp_scale(TEMP_SCALE scale);
       void set_esphome_temp_scale(TEMP_SCALE scale);
+      void set_client_id(uint8_t id);
 
       bool is_communicating();
 
@@ -102,6 +103,8 @@ namespace esphome
       uint8_t target_filter2_duration_minute = 0x00;
       bool target_filter2_enable = false;
       uint8_t client_id = 0x00;
+      uint8_t client_id_override = 0x00;
+      bool use_client_id_override = false;
       uint32_t last_received_time = 0;
       uint8_t send_preference_code = 0;
       uint8_t send_preference_data = 0;


### PR DESCRIPTION
Allows a client_id to be overridden at the device config

CC @robinostlund 

