### PR TITLE
Allow control of the jets via a fan component

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,25 @@ switch:
     blower:
       name: Blower
 
+# Fan platform for multi-speed jet control (recommended for jets with speed support)
+fan:
+  - platform: balboa_spa
+    balboa_spa_id: spa
+    jet_1:
+      name: "Jet 1"
+      id: jet1_fan
+      max_toggle_attempts: 5  # Optional: max attempts to reach desired state (default: 5)
+      discard_updates: 20     # Optional: state updates to ignore after each toggle (default: 20)
+    jet_2:
+      name: "Jet 2"
+      id: jet2_fan
+    jet_3:
+      name: "Jet 3"
+      id: jet3_fan
+    jet_4:
+      name: "Jet 4"
+      id: jet4_fan
+
 climate:
   - platform: balboa_spa
     balboa_spa_id: spa
@@ -143,6 +162,72 @@ button:
     disable_filter2:
       name: "Disable Filter 2"
 ```
+
+## Jet Control: Switch vs Fan Components
+
+This component provides two ways to control your spa jets, each with different capabilities:
+
+### Fan Components
+
+The **fan** platform provides full control over multi-speed jets with three distinct states:
+- **OFF** - Jet is completely off
+- **LOW** - Low speed (speed 1)
+- **HIGH** - High speed (speed 2)
+
+**Configuration:**
+```yaml
+fan:
+  - platform: balboa_spa
+    balboa_spa_id: spa
+    jet_1:
+      name: "Jet 1"
+      max_toggle_attempts: 5  # Optional, default: 5
+      discard_updates: 20     # Optional, default: 20
+```
+
+### Switch Components (Simple ON/OFF Control)
+
+The **switch** platform provides simple boolean control:
+- **OFF** - Jet is off
+- **ON** - Jet is on (typically LOW speed)
+
+**When to use switches:**
+- Your spa only supports simple ON/OFF jets (no multi-speed)
+- You prefer simple toggle behavior
+- You need backwards compatibility with existing automations
+
+**Configuration:**
+```yaml
+switch:
+  - platform: balboa_spa
+    balboa_spa_id: spa
+    jet1:
+      name: Jet1
+      max_toggle_attempts: 5  # Optional, default: 5
+      discard_updates: 20      # Optional, default: 20
+```
+
+### MAX_TOGGLE_ATTEMPTS Behavior
+
+Both switch and fan components support two configurable parameters:
+
+**`max_toggle_attempts`** (default: 5) - Maximum retry attempts when spa blocks state changes
+**`discard_updates`** (default: 20) - Number of state updates to ignore after each toggle command
+
+These work together to handle cases where the spa temporarily blocks state changes:
+
+- **Why it's needed:** During heating or filter cycles, the spa may prevent jets from turning off
+- **How it works:** If a state change is requested but not achieved, the component will retry on each spa state update
+- **Max attempts:** After reaching the maximum number of attempts, the component will sync with the actual spa state and stop retrying
+- **Typical value:** 5 attempts is usually sufficient (covers about 5-10 seconds)
+- **Discard updates:** After each toggle command, the component ignores the next 20 state updates to allow the spa to process the change
+
+**Example scenario:** If you try to turn off a jet during a heating cycle:
+1. Component sends toggle command
+2. Spa ignores the command (heating in progress)
+3. Component retries on next state update
+4. After heating completes, spa accepts the command
+5. Jet turns off successfully
 
 ## Troubleshooting
 

--- a/components/balboa_spa/fan/__init__.py
+++ b/components/balboa_spa/fan/__init__.py
@@ -1,0 +1,60 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import fan
+
+from esphome.const import (
+    ICON_FAN,
+)
+
+from .. import (
+    balboa_spa_ns,
+    BalboaSpa,
+    CONF_SPA_ID
+)
+
+DEPENDENCIES = ["balboa_spa"]
+
+Jet1Fan = balboa_spa_ns.class_("Jet1Fan", fan.Fan)
+Jet2Fan = balboa_spa_ns.class_("Jet2Fan", fan.Fan)
+Jet3Fan = balboa_spa_ns.class_("Jet3Fan", fan.Fan)
+Jet4Fan = balboa_spa_ns.class_("Jet4Fan", fan.Fan)
+
+CONF_JET_1 = "jet_1"
+CONF_JET_2 = "jet_2"
+CONF_JET_3 = "jet_3"
+CONF_JET_4 = "jet_4"
+CONF_MAX_TOGGLE_ATTEMPTS = "max_toggle_attempts"
+CONF_DISCARD_UPDATES = "discard_updates"
+
+def jet_fan_schema(cls):
+    return fan.fan_schema(cls).extend({
+        cv.Optional(CONF_MAX_TOGGLE_ATTEMPTS, default=5): cv.positive_int,
+        cv.Optional(CONF_DISCARD_UPDATES, default=20): cv.positive_int,
+    })
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_SPA_ID): cv.use_id(BalboaSpa),
+        cv.Optional(CONF_JET_1): jet_fan_schema(Jet1Fan),
+        cv.Optional(CONF_JET_2): jet_fan_schema(Jet2Fan),
+        cv.Optional(CONF_JET_3): jet_fan_schema(Jet3Fan),
+        cv.Optional(CONF_JET_4): jet_fan_schema(Jet4Fan),
+    })
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_SPA_ID])
+
+    for fan_type, cls in [
+        (CONF_JET_1, Jet1Fan),
+        (CONF_JET_2, Jet2Fan),
+        (CONF_JET_3, Jet3Fan),
+        (CONF_JET_4, Jet4Fan),
+    ]:
+        if conf := config.get(fan_type):
+            fan_var = cg.new_Pvariable(conf[cv.CONF_ID])
+            await fan.register_fan(fan_var, conf)
+            cg.add(fan_var.set_parent(parent))
+            if CONF_MAX_TOGGLE_ATTEMPTS in conf:
+                cg.add(fan_var.set_max_toggle_attempts(conf[CONF_MAX_TOGGLE_ATTEMPTS]))
+            if CONF_DISCARD_UPDATES in conf:
+                cg.add(fan_var.set_discard_updates(conf[CONF_DISCARD_UPDATES]))

--- a/components/balboa_spa/fan/jet1_fan.cpp
+++ b/components/balboa_spa/fan/jet1_fan.cpp
@@ -1,0 +1,13 @@
+#include "jet1_fan.h"
+
+namespace esphome
+{
+    namespace balboa_spa
+    {
+        void Jet1Fan::toggle_jet()
+        {
+            spa->toggle_jet1();
+        }
+
+    } // namespace balboa_spa
+} // namespace esphome

--- a/components/balboa_spa/fan/jet1_fan.h
+++ b/components/balboa_spa/fan/jet1_fan.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "jet_fan_base.h"
+
+namespace esphome
+{
+    namespace balboa_spa
+    {
+
+        class Jet1Fan : public JetFanBase
+        {
+        public:
+            Jet1Fan() : JetFanBase("BalboaSpa.Jet1Fan", "jet1") {};
+
+        protected:
+            double get_jet_state(const SpaState *spaState) override { return spaState->jet1; }
+            void toggle_jet() override;
+        };
+
+    } // namespace balboa_spa
+} // namespace esphome

--- a/components/balboa_spa/fan/jet2_fan.cpp
+++ b/components/balboa_spa/fan/jet2_fan.cpp
@@ -1,0 +1,13 @@
+#include "jet2_fan.h"
+
+namespace esphome
+{
+    namespace balboa_spa
+    {
+        void Jet2Fan::toggle_jet()
+        {
+            spa->toggle_jet2();
+        }
+
+    } // namespace balboa_spa
+} // namespace esphome

--- a/components/balboa_spa/fan/jet2_fan.h
+++ b/components/balboa_spa/fan/jet2_fan.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "jet_fan_base.h"
+
+namespace esphome
+{
+    namespace balboa_spa
+    {
+
+        class Jet2Fan : public JetFanBase
+        {
+        public:
+            Jet2Fan() : JetFanBase("BalboaSpa.Jet2Fan", "jet2") {};
+
+        protected:
+            double get_jet_state(const SpaState *spaState) override { return spaState->jet2; }
+            void toggle_jet() override;
+        };
+
+    } // namespace balboa_spa
+} // namespace esphome

--- a/components/balboa_spa/fan/jet3_fan.cpp
+++ b/components/balboa_spa/fan/jet3_fan.cpp
@@ -1,0 +1,13 @@
+#include "jet3_fan.h"
+
+namespace esphome
+{
+    namespace balboa_spa
+    {
+        void Jet3Fan::toggle_jet()
+        {
+            spa->toggle_jet3();
+        }
+
+    } // namespace balboa_spa
+} // namespace esphome

--- a/components/balboa_spa/fan/jet3_fan.h
+++ b/components/balboa_spa/fan/jet3_fan.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "jet_fan_base.h"
+
+namespace esphome
+{
+    namespace balboa_spa
+    {
+
+        class Jet3Fan : public JetFanBase
+        {
+        public:
+            Jet3Fan() : JetFanBase("BalboaSpa.Jet3Fan", "jet3") {};
+
+        protected:
+            double get_jet_state(const SpaState *spaState) override { return spaState->jet3; }
+            void toggle_jet() override;
+        };
+
+    } // namespace balboa_spa
+} // namespace esphome

--- a/components/balboa_spa/fan/jet4_fan.cpp
+++ b/components/balboa_spa/fan/jet4_fan.cpp
@@ -1,0 +1,13 @@
+#include "jet4_fan.h"
+
+namespace esphome
+{
+    namespace balboa_spa
+    {
+        void Jet4Fan::toggle_jet()
+        {
+            spa->toggle_jet4();
+        }
+
+    } // namespace balboa_spa
+} // namespace esphome

--- a/components/balboa_spa/fan/jet4_fan.h
+++ b/components/balboa_spa/fan/jet4_fan.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "jet_fan_base.h"
+
+namespace esphome
+{
+    namespace balboa_spa
+    {
+
+        class Jet4Fan : public JetFanBase
+        {
+        public:
+            Jet4Fan() : JetFanBase("BalboaSpa.Jet4Fan", "jet4") {};
+
+        protected:
+            double get_jet_state(const SpaState *spaState) override { return spaState->jet4; }
+            void toggle_jet() override;
+        };
+
+    } // namespace balboa_spa
+} // namespace esphome

--- a/components/balboa_spa/fan/jet_fan_base.cpp
+++ b/components/balboa_spa/fan/jet_fan_base.cpp
@@ -1,0 +1,126 @@
+#include "jet_fan_base.h"
+
+namespace esphome
+{
+    namespace balboa_spa
+    {
+        fan::FanTraits JetFanBase::get_traits()
+        {
+            return fan::FanTraits(false, true, false, 2);
+        }
+
+        void JetFanBase::update(const SpaState *spaState)
+        {
+            // Fan states: 0=OFF, 1=LOW, 2=HIGH
+            double jet_raw_state = this->get_jet_state(spaState);
+            int jet_state = static_cast<int>(jet_raw_state);
+
+            // Determine desired state from fan control
+            int desired_state = 0;
+            if (this->state)
+            {
+                // Fan is ON - determine speed (1=LOW, 2=HIGH)
+                desired_state = (this->speed >= 2) ? 2 : 1;
+            }
+
+            // Use base class update logic
+            this->update_toggle_state(
+                spaState,
+                desired_state,
+                current_fan_state,
+                [this](int new_state)
+                {
+                    if (new_state == 0)
+                    {
+                        // OFF
+                        if (this->state != false)
+                        {
+                            this->state = false;
+                            this->speed = 0;
+                            this->publish_state();
+                        }
+                    }
+                    else if (new_state == 1)
+                    {
+                        // LOW
+                        if (this->state != true || this->speed != 1)
+                        {
+                            this->state = true;
+                            this->speed = 1;
+                            this->publish_state();
+                        }
+                    }
+                    else if (new_state == 2)
+                    {
+                        // HIGH
+                        if (this->state != true || this->speed != 2)
+                        {
+                            this->state = true;
+                            this->speed = 2;
+                            this->publish_state();
+                        }
+                    }
+                });
+        }
+
+        void JetFanBase::set_parent(BalboaSpa *parent)
+        {
+            JetToggleComponentBase::set_parent(parent);
+            parent->register_listener([this](const SpaState *spaState)
+                                      { this->update(spaState); });
+        }
+
+        void JetFanBase::control(const fan::FanCall &call)
+        {
+            SpaState *spaState = spa->get_current_state();
+            double jet_raw_state = this->get_jet_state(spaState);
+
+            // Handle state change
+            if (call.get_state().has_value())
+            {
+                bool new_state = *call.get_state();
+                if (new_state)
+                {
+                    // Turning ON - check if speed is specified
+                    int target_speed = 1; // Default to LOW
+                    if (call.get_speed().has_value())
+                    {
+                        int speed_val = *call.get_speed();
+                        target_speed = (speed_val >= 2) ? 2 : 1;
+                    }
+                    else if (this->speed > 0)
+                    {
+                        // Use current speed if already set
+                        target_speed = this->speed;
+                    }
+
+                    ESP_LOGD(tag, "Spa/%s/fan: turning ON at speed %d", jet_name, target_speed);
+                    this->state = true;
+                    this->speed = target_speed;
+                    this->request_state_change(target_speed, jet_raw_state);
+                }
+                else
+                {
+                    // Turning OFF
+                    ESP_LOGD(tag, "Spa/%s/fan: turning OFF", jet_name);
+                    this->state = false;
+                    this->speed = 0;
+                    this->request_state_change(0, jet_raw_state);
+                }
+            }
+            // Handle speed change while already ON
+            else if (call.get_speed().has_value() && this->state)
+            {
+                int new_speed = *call.get_speed();
+                int target_speed = (new_speed >= 2) ? 2 : 1;
+
+                ESP_LOGD(tag, "Spa/%s/fan: changing speed to %d", jet_name, target_speed);
+                this->speed = target_speed;
+                this->request_state_change(target_speed, jet_raw_state);
+            }
+
+            this->publish_state();
+        }
+
+    } // namespace balboa_spa
+} // namespace esphome

--- a/components/balboa_spa/fan/jet_fan_base.h
+++ b/components/balboa_spa/fan/jet_fan_base.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/fan/fan.h"
+#include "../jet_toggle_component_base.h"
+
+namespace esphome
+{
+    namespace balboa_spa
+    {
+        /**
+         * @brief Base class for jet fan components
+         *
+         * Provides fan interface for multi-speed jets (OFF/LOW/HIGH).
+         * Uses JetToggleComponentBase for reliable state transitions with retry logic.
+         */
+        class JetFanBase : public fan::Fan, public JetToggleComponentBase
+        {
+        public:
+            JetFanBase(const char *tag, const char *jet_name)
+                : JetToggleComponentBase(tag, jet_name) {};
+
+            void update(const SpaState *spaState);
+            void set_parent(BalboaSpa *parent);
+            void set_max_toggle_attempts(uint8_t value) { JetToggleComponentBase::set_max_toggle_attempts(value); }
+            void set_discard_updates(uint8_t value) { JetToggleComponentBase::set_discard_updates(value); }
+
+            fan::FanTraits get_traits() override;
+
+        protected:
+            void control(const fan::FanCall &call) override;
+            virtual double get_jet_state(const SpaState *spaState) = 0;
+            virtual void toggle_jet() = 0;
+
+        private:
+            int current_fan_state = 0; // 0=OFF, 1=LOW, 2=HIGH
+        };
+
+    } // namespace balboa_spa
+} // namespace esphome

--- a/test_balboa_spa_component.yaml
+++ b/test_balboa_spa_component.yaml
@@ -32,6 +32,26 @@ switch:
     blower:
       name: Blower
 
+fan:
+  - platform: balboa_spa
+    balboa_spa_id: test_spa
+    jet_1:
+      name: "Jet 1 Fan"
+      id: jet1_fan
+      max_toggle_attempts: 4
+    jet_2:
+      name: "Jet 2 Fan"
+      id: jet2_fan
+      discard_updates: 10
+    jet_3:
+      name: "Jet 3 Fan"
+      id: jet3_fan
+    jet_4:
+      name: "Jet 4 Fan"
+      id: jet4_fan
+      discard_updates: 5
+      max_toggle_attempts: 2
+
 climate:
   - platform: balboa_spa
     balboa_spa_id: test_spa


### PR DESCRIPTION
# Add Fan Platform for Multi-Speed Jet Control

## Overview

This PR adds ESPHome **fan platform** support to the Balboa Spa component, enabling full control over multi-speed jets with OFF, LOW, and HIGH states. This provides more granular control than the existing switch components, which only support binary ON/OFF states.

## Motivation

Many spa jets support multiple speed settings (OFF → LOW → HIGH), but the existing switch platform only exposes binary ON/OFF control. When using switches:
- Turning a jet "ON" sets it to LOW speed
- There's no way to explicitly control HIGH speed through Home Assistant UI
- Users lose the ability to leverage ESPHome's built-in fan speed controls

The fan platform solves this by:
- Exposing all three jet states (OFF, LOW, HIGH)
- Providing native fan speed controls in Home Assistant
- Enabling more sophisticated automations based on jet speed

## What's New

### Fan Platform Components

Four new fan components that leverage the refactored toggle logic:

- **`jet_1`** - Controls Jet 1 with OFF/LOW/HIGH states
- **`jet_2`** - Controls Jet 2 with OFF/LOW/HIGH states  
- **`jet_3`** - Controls Jet 3 with OFF/LOW/HIGH states
- **`jet_4`** - Controls Jet 4 with OFF/LOW/HIGH states

### Configuration Example

```yaml
fan:
  - platform: balboa_spa
    balboa_spa_id: spa
    jet_1:
      name: "Jet 1"
      id: jet1_fan
      max_toggle_attempts: 5  # Optional: default is 5
      discard_updates: 5      # Optional: default is 5
    jet_2:
      name: "Jet 2"
      id: jet2_fan
    jet_3:
      name: "Jet 3"
      id: jet3_fan
    jet_4:
      name: "Jet 4"
      id: jet4_fan
```

### Fan-Specific Features

The fan implementation adds:
- **Three-state control**: OFF (0), LOW (1), HIGH (2)
- **Speed control**: Maps ESPHome fan speeds to jet states
- **State tracking**: Maintains separate state for accurate UI feedback
- **Home Assistant integration**: Native fan entity with speed controls

### Files Added

```
components/balboa_spa/fan/
├── __init__.py              # Fan platform registration
├── jet_fan_base.cpp/.h      # Base fan implementation
├── jet1_fan.cpp/.h          # Jet 1 fan component
├── jet2_fan.cpp/.h          # Jet 2 fan component
├── jet3_fan.cpp/.h          # Jet 3 fan component
└── jet4_fan.cpp/.h          # Jet 4 fan component
```

Closes #15
