### PR TITLE
Let jet switches accept any non-zero state as on

### DIFF
--- a/components/balboa_spa/jet_toggle_component_base.cpp
+++ b/components/balboa_spa/jet_toggle_component_base.cpp
@@ -54,7 +54,7 @@ namespace esphome
             }
 
             // Check if we've reached the target state
-            if (jet_state == target_state)
+            if (this->state_matches_target(jet_state, target_state))
             {
                 this->desired_state = ToggleStateMaybe::DONT_KNOW;
                 this->toggle_attempts = 0;
@@ -104,7 +104,7 @@ namespace esphome
         {
             int current_state = static_cast<int>(current_jet_state);
 
-            if (current_state == target_state)
+            if (this->state_matches_target(current_state, target_state))
             {
                 ESP_LOGD(tag, "Spa/%s: already at target state %d", jet_name, target_state);
                 return;

--- a/components/balboa_spa/jet_toggle_component_base.h
+++ b/components/balboa_spa/jet_toggle_component_base.h
@@ -38,6 +38,19 @@ namespace esphome
             virtual void toggle_jet() = 0;
 
             /**
+             * @brief Decide whether the reported jet state satisfies the target.
+             *
+             * Default is an exact match, which is what fans need (0/1/2 map to
+             * OFF/LOW/HIGH). Switches override this: for them any non-zero
+             * state counts as "on", because some mainboards only ever report
+             * state 2 for a single-speed pump.
+             */
+            virtual bool state_matches_target(int jet_state, int target_state)
+            {
+                return jet_state == target_state;
+            }
+
+            /**
              * @brief Update logic called when spa state changes
              * @param spaState Current spa state
              * @param desired_state Desired jet state (0=OFF, 1=LOW, 2=HIGH)

--- a/components/balboa_spa/switch/jet_switch_base.cpp
+++ b/components/balboa_spa/switch/jet_switch_base.cpp
@@ -31,6 +31,18 @@ namespace esphome
                 });
         }
 
+        bool JetSwitchBase::state_matches_target(int jet_state, int target_state)
+        {
+            // A switch only distinguishes off from on. Some mainboards report a
+            // single-speed pump as state 2, so treat any non-zero state as "on"
+            // instead of demanding an exact match on 1.
+            if (target_state == 0)
+            {
+                return jet_state == 0;
+            }
+            return jet_state > 0;
+        }
+
         void JetSwitchBase::set_parent(BalboaSpa *parent)
         {
             JetToggleComponentBase::set_parent(parent);

--- a/components/balboa_spa/switch/jet_switch_base.h
+++ b/components/balboa_spa/switch/jet_switch_base.h
@@ -24,6 +24,7 @@ namespace esphome
             void write_state(bool state) override;
             virtual double get_jet_state(const SpaState *spaState) = 0;
             virtual void toggle_jet() = 0;
+            bool state_matches_target(int jet_state, int target_state) override;
 
         private:
             int current_switch_state_ = 0; // 0=OFF, >0=ON for switch


### PR DESCRIPTION
JetSwitchBase::write_state() hardcodes the ON target to 1 and update_toggle_state() requires an exact match against the reported jet state.

Some mainboards report a running single-speed pump as state 2 and never 1. On those, the switch never recognises success: it concludes the toggle failed and toggles again, which physically turns the pump off, then sees 0 != 1 and toggles again. The pump cycles on and off until max_toggle_attempts runs out. Reproduced on a BP200G2, where "pump1":1 in the spa configuration confirms a single speed pump that nonetheless reports state 2.

The read path already handles this - bool switch_state = (jet_state > 0) - so only the write path assumed 1.

Adds a virtual state_matches_target() to JetToggleComponentBase defaulting to the current exact comparison, so fans are unaffected, and overrides it in JetSwitchBase so a non-zero target accepts any non-zero state. Also applied in request_state_change(), which used the same exact comparison to decide whether a toggle was needed at all.