### PR TITLE
Bound BlowerSwitch retries and expose max_toggle_attempts

### DIFF
--- a/components/balboa_spa/switch/__init__.py
+++ b/components/balboa_spa/switch/__init__.py
@@ -71,6 +71,7 @@ CONFIG_SCHEMA = cv.Schema(
             icon=ICON_GRAIN,
             default_restore_mode="DISABLED",
         ).extend({
+            cv.Optional(CONF_MAX_TOGGLE_ATTEMPTS, default=5): cv.positive_int,
             cv.Optional(CONF_DISCARD_UPDATES, default=20): cv.positive_int,
         }),
         cv.Optional(CONF_HIGHRANGE): switch.switch_schema(

--- a/components/balboa_spa/switch/blower_switch.cpp
+++ b/components/balboa_spa/switch/blower_switch.cpp
@@ -17,20 +17,35 @@ namespace esphome
                 this->publish_state(spaState->blower);
                 ESP_LOGD("blower_swtich", "Blower switch state updated to %s", spaState->blower ? STRON : STROFF);
             }
-            else if (this->setState == ToggleStateMaybe::ON && !spaState->blower)
+            else if ((this->setState == ToggleStateMaybe::ON && !spaState->blower) ||
+                     (this->setState == ToggleStateMaybe::OFF && spaState->blower))
             {
-                this->toggle_blower();
-                ESP_LOGD("blower_swtich", "Blower state changed %s setState is ON, toggling blower", state ? STRON : STROFF);
-            }
-            else if (this->setState == ToggleStateMaybe::OFF && spaState->blower)
-            {
-                this->toggle_blower();
-                ESP_LOGD("blower_swtich", "Blower state changed %s setState is OFF, toggling blower", state ? STRON : STROFF);
+                // Bounded retry: without a limit this loops forever whenever the
+                // spa refuses the command, or when the mainboard has no blower
+                // at all and never reports the requested state.
+                if (this->toggle_attempts_ < this->max_toggle_attempts_)
+                {
+                    this->toggle_attempts_++;
+                    this->toggle_blower();
+                    ESP_LOGD("blower_switch", "Toggling blower (attempt %d/%d), setState is %s",
+                             this->toggle_attempts_, this->max_toggle_attempts_,
+                             TOGGLE_STATE_MAYBE_STRINGS[this->setState]);
+                }
+                else
+                {
+                    ESP_LOGW("blower_switch", "Failed to reach target state after %d attempts - "
+                                              "spa may be in filter cycle, or this spa has no blower",
+                             this->max_toggle_attempts_);
+                    this->setState = ToggleStateMaybe::DONT_KNOW;
+                    this->toggle_attempts_ = 0;
+                    this->publish_state(spaState->blower);
+                }
             }
             else if (this->setState != ToggleStateMaybe::DONT_KNOW)
             {
                 this->setState = ToggleStateMaybe::DONT_KNOW;
-                ESP_LOGD("blower_swtich", "write_state sucessful, setState is now DONT_KNOW");
+                this->toggle_attempts_ = 0;
+                ESP_LOGD("blower_switch", "write_state successful, setState is now DONT_KNOW");
             }
         }
 
@@ -55,6 +70,7 @@ namespace esphome
             if (spaState->blower != state)
             {
                 this->setState = state ? ToggleStateMaybe::ON : ToggleStateMaybe::OFF;
+                this->toggle_attempts_ = 0;
                 this->toggle_blower();
             }
         }

--- a/components/balboa_spa/switch/blower_switch.h
+++ b/components/balboa_spa/switch/blower_switch.h
@@ -16,6 +16,7 @@ namespace esphome
       void update(const SpaState *spaState);
       void set_parent(BalboaSpa *parent);
       void set_discard_updates(uint8_t value) { this->discard_updates_config_ = value; }
+      void set_max_toggle_attempts(uint8_t value) { this->max_toggle_attempts_ = value; }
 
     protected:
       void write_state(bool state) override;
@@ -26,6 +27,8 @@ namespace esphome
       ToggleStateMaybe setState = ToggleStateMaybe::DONT_KNOW;
       uint8_t discard_updates = 0;
       uint8_t discard_updates_config_ = 10;
+      uint8_t toggle_attempts_ = 0;
+      uint8_t max_toggle_attempts_ = 5;
     };
 
   } // namespace balboa_spa


### PR DESCRIPTION
BlowerSwitch has no equivalent of the jet switches' max_toggle_attempts. If the requested state is never reached it calls toggle_blower() on every state update, indefinitely.

This is easy to hit on a spa with no blower fitted at all - "blower":0 in the spa configuration where the requested state can never be reached. Observed as a toggle roughly once per second until the switch was turned off again.

Bounds the retries the same way the jet switches are bounded, resyncs the published state with the spa afterwards, and exposes max_toggle_attempts for the blower in the config schema, where it was only available for the jets.

Also fixes the 'blower_swtich' log tag and 'sucessful' typos.