### PR TITLE
Avoid reading an empty deque in CircularBuffer, fix off-by-one

### DIFF
--- a/components/balboa_spa/CircularBuffer.h
+++ b/components/balboa_spa/CircularBuffer.h
@@ -60,7 +60,7 @@ namespace esphome
 
             bool push(T val)
             {
-                if (this->max_size < this->backingQue.size())
+                if (this->max_size <= this->backingQue.size())
                 {
                     this->backingQue.pop_front();
                     this->backingQue.push_back(val);
@@ -72,11 +72,23 @@ namespace esphome
 
             const T &last()
             {
+                if (this->backingQue.empty())
+                {
+                    ESP_LOGV(CIRCULAR_BUFFER_TAG, "last() called on empty buffer");
+                    static const T empty_value{};
+                    return empty_value;
+                }
                 return backingQue.back();
             };
 
             const T &first()
             {
+                if (this->backingQue.empty())
+                {
+                    ESP_LOGV(CIRCULAR_BUFFER_TAG, "first() called on empty buffer");
+                    static const T empty_value{};
+                    return empty_value;
+                }
                 return backingQue.front();
             };
 
@@ -89,7 +101,7 @@ namespace esphome
             {
                 if (index >= this->size())
                 {
-                    ESP_LOGE(CIRCULAR_BUFFER_TAG, "INDEX %d out of bounds. size=%d", index, this->size());
+                    ESP_LOGE(CIRCULAR_BUFFER_TAG, "INDEX %u out of bounds. size=%u", (unsigned)index, (unsigned)this->size());
                     return T();
                 }
                 return backingQue.at(index);
@@ -102,6 +114,11 @@ namespace esphome
 
             T pop()
             {
+                if (this->backingQue.empty())
+                {
+                    ESP_LOGV(CIRCULAR_BUFFER_TAG, "pop() called on empty buffer");
+                    return T();
+                }
                 T val = backingQue.back();
                 backingQue.pop_back();
                 return val;
@@ -109,7 +126,7 @@ namespace esphome
 
             bool unshift(T val)
             {
-                if (this->max_size >= this->backingQue.size())
+                if (this->max_size > this->backingQue.size())
                 {
                     this->backingQue.push_front(val);
                     return true;

--- a/components/balboa_spa/balboaspa.cpp
+++ b/components/balboa_spa/balboaspa.cpp
@@ -291,8 +291,18 @@ namespace esphome
                 return;
             }
 
-            // Drop until SOF is seen
-            if (input_queue.first() != 0x7E && received_byte != 0x7E)
+            // Drop until SOF is seen.
+            //
+            // An empty buffer is the normal state between frames, so check for it
+            // explicitly rather than reading first() off an empty deque.
+            if (input_queue.size() == 0)
+            {
+                if (received_byte != 0x7E)
+                {
+                    return;
+                }
+            }
+            else if (input_queue.first() != 0x7E && received_byte != 0x7E)
             {
                 input_queue.clear();
                 return;


### PR DESCRIPTION
first(), last() and pop() call front()/back() on the underlying std::deque without checking whether it is empty, which is undefined behaviour.

read_serial() reaches this on the normal path: the "drop until SOF is seen" check reads input_queue.first() for every byte received while the buffer is empty, which is the state between frames and after every clear(). In practice it returned whatever happened to be on the stack.

Fixed at the call site by checking for an empty buffer explicitly, which also makes the intent clearer, and defensively in the buffer itself. The buffer logs at VERBOSE rather than ERROR, since a caller asking an empty buffer for its first element is not necessarily a bug.

Also:
- push() used '<' where it needs '<=', so the buffer held max_size + 1 items. unshift() had the mirrored off-by-one.
- The operator[] bounds log used %d for size_t arguments.