### PR TITLE
Fix request chain deadlock, expose filter settings and config buttons

### DIFF
--- a/components/balboa_spa/balboaspa.cpp
+++ b/components/balboa_spa/balboaspa.cpp
@@ -33,6 +33,65 @@ namespace esphome
                 status_clear_error();
             }
 
+            // Config request timeout guard.
+            //
+            // The spa does not always answer the first request, and without a
+            // retry the status sits at 1 forever, so the hardware configuration
+            // is never reported.
+            if (config_request_status == 1)
+            {
+                config_response_timer++;
+                if (config_response_timer >= 200) // 200 * 50ms = 10 seconds
+                {
+                    config_response_timer = 0;
+                    if (config_retries < 3)
+                    {
+                        config_retries++;
+                        config_request_status = 0; // ask again
+                        ESP_LOGW(TAG, "Spa/config/status: no response, retry %d/3", config_retries);
+                    }
+                    else
+                    {
+                        config_request_status = 3; // give up, unblock the chain
+                        ESP_LOGW(TAG, "Spa/config/status: %s", "no response after 3 retries, giving up");
+                    }
+                }
+            }
+            else
+            {
+                config_response_timer = 0;
+            }
+
+            // Fault log timeout guard.
+            //
+            // The request chain only asks for the filter settings once the fault
+            // log has come back. If the spa never answers, the status stays at 1
+            // forever and the filter schedule is never refreshed again. Retry a
+            // few times, then mark it abandoned so the chain can move on.
+            if (faultlog_request_status == 1)
+            {
+                faultlog_response_timer++;
+                if (faultlog_response_timer >= 200) // 200 * 50ms = 10 seconds
+                {
+                    faultlog_response_timer = 0;
+                    if (faultlog_retries < 3)
+                    {
+                        faultlog_retries++;
+                        faultlog_request_status = 0; // ask again
+                        ESP_LOGW(TAG, "Spa/debug/faultlog_request_status: no response, retry %d/3", faultlog_retries);
+                    }
+                    else
+                    {
+                        faultlog_request_status = 3; // give up, unblock the chain
+                        ESP_LOGW(TAG, "Spa/debug/faultlog_request_status: %s", "no response after 3 retries, giving up");
+                    }
+                }
+            }
+            else
+            {
+                faultlog_response_timer = 0;
+            }
+
             // Filter settings periodic update timer (every 5 minutes)
             if (filtersettings_request_status == 2)
             {
@@ -405,8 +464,11 @@ namespace esphome
                             ESP_LOGD(TAG, "Spa/debug/faultlog_request_status: %s", "requesting fault log, #1");
                         }
                         else if (filtersettings_request_status == 0 &&
-                                 (faultlog_request_status == 2 || faultlog_request_status == 0))
-                        { // Get the filter cycles log once we have the faultlog, or periodically
+                                 faultlog_request_status != 1)
+                        { // Get the filter cycles log once the fault log request has
+                          // finished, whether it succeeded (2), was already processed
+                          // (3) or was abandoned. Waiting only for status 2 meant an
+                          // unanswered fault log blocked this branch permanently.
                             output_queue.push(client_id);
                             output_queue.push(0xBF);
                             output_queue.push(0x22);
@@ -622,6 +684,8 @@ namespace esphome
             ESP_LOGD(TAG, "Spa/config/temperature_scale: %d", spaConfig.temperature_scale);
             ESP_LOGD(TAG, "Spa/config/clock_mode: %d", spaConfig.clock_mode);
             config_request_status = 2;
+            config_retries = 0;
+            config_response_timer = 0;
 
             if (spa_temp_scale == TEMP_SCALE::UNDEFINED)
             {
@@ -929,6 +993,8 @@ namespace esphome
             ESP_LOGD(TAG, "Spa/fault/Hours: %d", spaFaultLog.hour);
             ESP_LOGD(TAG, "Spa/fault/Minutes: %d", spaFaultLog.minutes);
             faultlog_request_status = 2;
+            faultlog_retries = 0;
+            faultlog_response_timer = 0;
             // ESP_LOGD(TAG, "Spa/debug/faultlog_request_status: have the faultlog, #2");
 
             // Notify fault log listeners

--- a/components/balboa_spa/balboaspa.h
+++ b/components/balboa_spa/balboaspa.h
@@ -126,6 +126,10 @@ namespace esphome
       char faultlog_request_status = 0;       // stages: 0-> want it; 1-> requested it; 2-> got it; 3-> further processed it
       char filtersettings_request_status = 0; // stages: 0-> want it; 1-> requested it; 2-> got it; 3-> further processed it
       char faultlog_update_timer = 0;         // temp logic so we only get the fault log once per 5 minutes
+      uint16_t faultlog_response_timer = 0;   // timeout guard for an unanswered fault log request
+      uint8_t faultlog_retries = 0;           // consecutive unanswered fault log requests
+      uint16_t config_response_timer = 0;     // timeout guard for an unanswered config request
+      uint8_t config_retries = 0;             // consecutive unanswered config requests
       uint16_t filtersettings_update_timer = 0;   // timer for periodic filter settings requests (every 5 minutes)
 
       SpaConfig spaConfig;

--- a/components/balboa_spa/button/__init__.py
+++ b/components/balboa_spa/button/__init__.py
@@ -9,11 +9,15 @@ SyncTimeButton = balboa_spa_ns.class_("SyncTimeButton", button.Button)
 DisableFilter2Button = balboa_spa_ns.class_("DisableFilter2Button", button.Button)
 RequestFaultLogButton = balboa_spa_ns.class_("RequestFaultLogButton", button.Button)
 ClearReminderButton = balboa_spa_ns.class_("ClearReminderButton", button.Button)
+RequestFilterSettingsButton = balboa_spa_ns.class_("RequestFilterSettingsButton", button.Button)
+RequestConfigButton = balboa_spa_ns.class_("RequestConfigButton", button.Button)
 
 CONF_SYNC_TIME = "sync_time"
 CONF_DISABLE_FILTER2 = "disable_filter2"
 CONF_REQUEST_FAULT_LOG = "request_fault_log"
 CONF_CLEAR_REMINDER = "clear_reminder"
+CONF_REQUEST_FILTER_SETTINGS = "request_filter_settings"
+CONF_REQUEST_CONFIG = "request_config"
 
 CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(CONF_SPA_ID): cv.use_id(BalboaSpa),
@@ -21,6 +25,8 @@ CONFIG_SCHEMA = cv.Schema({
     cv.Optional(CONF_DISABLE_FILTER2): button.button_schema(DisableFilter2Button),
     cv.Optional(CONF_REQUEST_FAULT_LOG): button.button_schema(RequestFaultLogButton),
     cv.Optional(CONF_CLEAR_REMINDER): button.button_schema(ClearReminderButton),
+    cv.Optional(CONF_REQUEST_FILTER_SETTINGS): button.button_schema(RequestFilterSettingsButton),
+    cv.Optional(CONF_REQUEST_CONFIG): button.button_schema(RequestConfigButton),
 })
 
 async def to_code(config):
@@ -35,5 +41,11 @@ async def to_code(config):
         var = await button.new_button(conf)
         cg.add(var.set_parent(parent))
     if conf := config.get(CONF_CLEAR_REMINDER):
+        var = await button.new_button(conf)
+        cg.add(var.set_parent(parent))
+    if conf := config.get(CONF_REQUEST_FILTER_SETTINGS):
+        var = await button.new_button(conf)
+        cg.add(var.set_parent(parent))
+    if conf := config.get(CONF_REQUEST_CONFIG):
         var = await button.new_button(conf)
         cg.add(var.set_parent(parent))

--- a/components/balboa_spa/button/request_config_button.cpp
+++ b/components/balboa_spa/button/request_config_button.cpp
@@ -1,0 +1,23 @@
+#include "request_config_button.h"
+#include "esphome/core/log.h"
+
+namespace esphome
+{
+    namespace balboa_spa
+    {
+        static const char *TAG = "balboa_spa.button";
+
+        void RequestConfigButton::set_parent(BalboaSpa *parent)
+        {
+            parent_ = parent;
+        }
+
+        void RequestConfigButton::press_action()
+        {
+            ESP_LOGD(TAG, "Request config button pressed");
+            parent_->request_config_update();
+            ESP_LOGI(TAG, "Spa config update requested");
+        }
+
+    } // namespace balboa_spa
+} // namespace esphome

--- a/components/balboa_spa/button/request_config_button.h
+++ b/components/balboa_spa/button/request_config_button.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "esphome/components/button/button.h"
+#include "../balboaspa.h"
+
+namespace esphome
+{
+    namespace balboa_spa
+    {
+
+        class RequestConfigButton : public button::Button
+        {
+        public:
+            void set_parent(BalboaSpa *parent);
+
+        protected:
+            void press_action() override;
+
+        private:
+            BalboaSpa *parent_;
+        };
+
+    } // namespace balboa_spa
+} // namespace esphome

--- a/components/balboa_spa/button/request_filter_settings_button.cpp
+++ b/components/balboa_spa/button/request_filter_settings_button.cpp
@@ -1,0 +1,23 @@
+#include "request_filter_settings_button.h"
+#include "esphome/core/log.h"
+
+namespace esphome
+{
+    namespace balboa_spa
+    {
+        static const char *TAG = "balboa_spa.button";
+
+        void RequestFilterSettingsButton::set_parent(BalboaSpa *parent)
+        {
+            parent_ = parent;
+        }
+
+        void RequestFilterSettingsButton::press_action()
+        {
+            ESP_LOGD(TAG, "Request filter settings button pressed");
+            parent_->request_filter_settings_update();
+            ESP_LOGI(TAG, "Filter settings update requested");
+        }
+
+    } // namespace balboa_spa
+} // namespace esphome

--- a/components/balboa_spa/button/request_filter_settings_button.h
+++ b/components/balboa_spa/button/request_filter_settings_button.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "esphome/components/button/button.h"
+#include "../balboaspa.h"
+
+namespace esphome
+{
+    namespace balboa_spa
+    {
+
+        class RequestFilterSettingsButton : public button::Button
+        {
+        public:
+            void set_parent(BalboaSpa *parent);
+
+        protected:
+            void press_action() override;
+
+        private:
+            BalboaSpa *parent_;
+        };
+
+    } // namespace balboa_spa
+} // namespace esphome


### PR DESCRIPTION
The filter settings are only requested once the fault log has arrived (faultlog_request_status == 2). The branch's own condition also allows 0, but that is unreachable: the preceding else-if catches 0 and fires the fault log request first.

If the spa does not answer the fault log request the status stays at 1 forever and the filter schedule is never refreshed again, not even by the five minute periodic timer, which resets filtersettings_request_status but cannot get past the blocked chain. Observed on a BP200G2 after a power cycle: the spa kept running its filter cycles correctly while the component reported {"start":"00:00","duration":"00:00"} and "disabled" indefinitely. Because filter1_running and filter2_running are derived from that schedule rather than reported by the spa, both sensors were wrong as well.

The config request has the same shape and no retry either, so when it went unanswered the hardware configuration simply never arrived.

Adds a timeout guard to both: three retries at ten second intervals, then marked abandoned so the chain moves on. In practice one retry is enough.

Also exposes request_filter_settings_update() and request_config_update() as buttons. Both existed on BalboaSpa but were missing from the config schema, so there was no way to force a refresh; only the fault log had a button.