### PR TITLE
Expose the spa hardware configuration as a text sensor

### DIFF
--- a/components/balboa_spa/balboaspa.cpp
+++ b/components/balboa_spa/balboaspa.cpp
@@ -621,6 +621,7 @@ namespace esphome
             ESP_LOGD(TAG, "Spa/config/aux2: %d", spaConfig.aux2);
             ESP_LOGD(TAG, "Spa/config/temperature_scale: %d", spaConfig.temperature_scale);
             ESP_LOGD(TAG, "Spa/config/clock_mode: %d", spaConfig.clock_mode);
+            spaConfig.valid = 1;
             config_request_status = 2;
 
             if (spa_temp_scale == TEMP_SCALE::UNDEFINED)

--- a/components/balboa_spa/spa_config.h
+++ b/components/balboa_spa/spa_config.h
@@ -11,6 +11,16 @@ namespace esphome
         struct SpaConfig
         {
         public:
+            // Bitfields are not zero initialised by default, and the struct is
+            // read before the spa has sent its configuration message. Without
+            // this constructor those first reads return whatever was on the
+            // stack.
+            SpaConfig()
+                : pump1(0), pump2(0), pump3(0), pump4(0), pump5(0), pump6(0),
+                  light1(0), light2(0), circ(0), blower(0), mister(0),
+                  aux1(0), aux2(0), temperature_scale(0), clock_mode(0),
+                  valid(0) {}
+
             uint8_t pump1 : 2; // this could be 1=1 speed; 2=2 speeds
             uint8_t pump2 : 2;
             uint8_t pump3 : 2;
@@ -26,6 +36,7 @@ namespace esphome
             uint8_t aux2 : 1;
             uint8_t temperature_scale : 1; // 1 -> Farenheit, 0-> Celcius
             uint8_t clock_mode : 1;        // 0 -> 12h, 1-> 24h
+            uint8_t valid : 1;            // 1 once the spa has reported its configuration
         };
 
     } // namespace balboa_spa

--- a/components/balboa_spa/text_sensor/__init__.py
+++ b/components/balboa_spa/text_sensor/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import text_sensor
 from .. import balboa_spa_ns, BalboaSpa, CONF_SPA_ID
+from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
 
 DEPENDENCIES = ["balboa_spa"]
 SpaTimeTextSensor = balboa_spa_ns.class_("SpaTimeTextSensor", text_sensor.TextSensor)
@@ -11,6 +12,7 @@ FaultMessageTextSensor = balboa_spa_ns.class_("FaultMessageTextSensor", text_sen
 FaultLogTimeTextSensor = balboa_spa_ns.class_("FaultLogTimeTextSensor", text_sensor.TextSensor)
 ReminderTextSensor = balboa_spa_ns.class_("ReminderTextSensor", text_sensor.TextSensor)
 ComponentVersionTextSensor = balboa_spa_ns.class_("ComponentVersionTextSensor", text_sensor.TextSensor)
+SpaConfigTextSensor = balboa_spa_ns.class_("SpaConfigTextSensor", text_sensor.TextSensor)
 
 CONF_SPA_TIME = "spa_time"
 CONF_FILTER1_CONFIG = "filter1_config"
@@ -19,6 +21,7 @@ CONF_FAULT_MESSAGE = "fault_message"
 CONF_FAULT_LOG_TIME = "fault_log_time"
 CONF_REMINDER = "reminder"
 CONF_COMPONENT_VERSION = "component_version"
+CONF_SPA_CONFIG = "spa_config"
 
 CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(CONF_SPA_ID): cv.use_id(BalboaSpa),
@@ -29,6 +32,11 @@ CONFIG_SCHEMA = cv.Schema({
     cv.Optional(CONF_FAULT_LOG_TIME): text_sensor.text_sensor_schema(FaultLogTimeTextSensor),
     cv.Optional(CONF_REMINDER): text_sensor.text_sensor_schema(ReminderTextSensor),
     cv.Optional(CONF_COMPONENT_VERSION): text_sensor.text_sensor_schema(ComponentVersionTextSensor),
+    cv.Optional(CONF_SPA_CONFIG): text_sensor.text_sensor_schema(
+        SpaConfigTextSensor,
+        icon="mdi:information-outline",
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
 })
 
 async def to_code(config):
@@ -52,5 +60,8 @@ async def to_code(config):
         var = await text_sensor.new_text_sensor(conf)
         cg.add(var.set_parent(parent))
     if conf := config.get(CONF_COMPONENT_VERSION):
+        var = await text_sensor.new_text_sensor(conf)
+        cg.add(var.set_parent(parent))
+    if conf := config.get(CONF_SPA_CONFIG):
         var = await text_sensor.new_text_sensor(conf)
         cg.add(var.set_parent(parent))

--- a/components/balboa_spa/text_sensor/spa_config_text_sensor.cpp
+++ b/components/balboa_spa/text_sensor/spa_config_text_sensor.cpp
@@ -1,0 +1,42 @@
+#include "spa_config_text_sensor.h"
+
+namespace esphome
+{
+    namespace balboa_spa
+    {
+
+        void SpaConfigTextSensor::set_parent(BalboaSpa *parent)
+        {
+            this->parent_ = parent;
+            parent->register_listener([this](SpaState *spaState)
+                                      { this->update(this->parent_->get_current_config()); });
+        }
+
+        void SpaConfigTextSensor::update(const SpaConfig &config)
+        {
+            // The configuration is static for a given spa and arrives once, a
+            // little after boot. Publish it as soon as it is valid, then stop.
+            if (config.valid == 0 || this->published_)
+            {
+                return;
+            }
+
+            char buf[220];
+            snprintf(buf, sizeof(buf),
+                     "{\"pump1\":%u,\"pump2\":%u,\"pump3\":%u,\"pump4\":%u,\"pump5\":%u,\"pump6\":%u,"
+                     "\"light1\":%u,\"light2\":%u,\"circ\":%u,\"blower\":%u,\"mister\":%u,"
+                     "\"aux1\":%u,\"aux2\":%u,\"temp_scale\":\"%s\",\"clock\":\"%s\"}",
+                     (unsigned)config.pump1, (unsigned)config.pump2, (unsigned)config.pump3,
+                     (unsigned)config.pump4, (unsigned)config.pump5, (unsigned)config.pump6,
+                     (unsigned)config.light1, (unsigned)config.light2, (unsigned)config.circ,
+                     (unsigned)config.blower, (unsigned)config.mister,
+                     (unsigned)config.aux1, (unsigned)config.aux2,
+                     config.temperature_scale ? "C" : "F",
+                     config.clock_mode ? "24h" : "12h");
+
+            this->publish_state(buf);
+            this->published_ = true;
+        }
+
+    } // namespace balboa_spa
+} // namespace esphome

--- a/components/balboa_spa/text_sensor/spa_config_text_sensor.h
+++ b/components/balboa_spa/text_sensor/spa_config_text_sensor.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "esphome/components/text_sensor/text_sensor.h"
+#include "../balboaspa.h"
+
+namespace esphome
+{
+    namespace balboa_spa
+    {
+
+        /**
+         * @brief Exposes the hardware configuration the spa reports about itself.
+         *
+         * The mainboard sends a configuration message shortly after boot that
+         * describes how many pumps are fitted and how many speeds each has, and
+         * whether a circulation pump, blower, mister, lights or aux outputs are
+         * present. That message was decoded and logged but never surfaced, so
+         * there was no way to tell from Home Assistant which hardware a given
+         * spa actually has.
+         */
+        class SpaConfigTextSensor : public text_sensor::TextSensor
+        {
+        public:
+            void set_parent(BalboaSpa *parent);
+            void update(const SpaConfig &config);
+
+        private:
+            BalboaSpa *parent_{nullptr};
+            bool published_{false};
+        };
+
+    } // namespace balboa_spa
+} // namespace esphome


### PR DESCRIPTION
decodeSettings() decodes the configuration the mainboard reports about itself how many pumps are fitted and how many speeds each has, and whether a circulation pump, blower, mister, lights or aux outputs are present, plus the temperature scale and clock mode. It logs all of it once at debug level and then discards it: get_current_config() is not called from anywhere.

That information answers questions that are otherwise worked out from behaviour. On my spa "blower":0 explained why the blower switch could never reach its target, and "pump1":1 confirmed a single-speed pump that reports state 2.

Adds a spa_config text sensor publishing it as JSON:

  {"pump1":1,"pump2":1,"pump3":0,"pump4":0,"pump5":0,"pump6":0,"light1":1,
   "light2":0,"circ":1,"blower":0,"mister":0,"aux1":0,"aux2":0,
   "temp_scale":"C","clock":"24h"}

SpaConfig also had no constructor, so its bitfields held whatever was on the stack until the configuration message arrived. Added one, along with a valid flag so consumers can tell real data from the initial state.